### PR TITLE
Allow 'chrome-extension://' protocol

### DIFF
--- a/window_creater.js
+++ b/window_creater.js
@@ -2,7 +2,7 @@
 var windowCreater = {
     
     makeNewWindow: function(srcurl) {
-        if (srcurl.indexOf("http://") != 0 && srcurl.indexOf("https://") != 0 && srcurl.indexOf("file://") != 0 && srcurl.indexOf("chrome://") != 0) {
+        if (srcurl.indexOf("http://") != 0 && srcurl.indexOf("https://") != 0 && srcurl.indexOf("file://") != 0 && srcurl.indexOf("chrome://") != 0 && srcurl.indexOf("chrome-extension://") != 0) {
             // Needs a procotol
             srcurl = "http://" + srcurl;
         }


### PR DESCRIPTION
This tiny change is very useful because it allows PIP Viewer to open other chrome extensions in Panels. For example, now I have a bookmarks panel (Neater Bookmarks extension's popup) that stays open.
